### PR TITLE
Correct encode values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,23 @@
 {
   "name": "zustand-cookie-storage",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zustand-cookie-storage",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "ISC",
       "devDependencies": {
-        "typescript": "^5.4.5"
+        "typescript": "^5.7.3"
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zustand-cookie-storage",
-  "version": "1.0.6",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zustand-cookie-storage",
-      "version": "1.0.6",
+      "version": "1.1.1",
       "license": "ISC",
       "devDependencies": {
         "typescript": "^5.4.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zustand-cookie-storage",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "`zustand-cookie-storage` is a utility library designed to enhance the state management capabilities of Zustand by persisting state in cookies. This package enables seamless storage and retrieval of state across sessions and browser tabs using cookies as a storage medium. It is particularly useful for maintaining user preferences, session information, and other critical state that should persist even after the user closes or refreshes the browser.",
   "main": "dist/index.js",
   "scripts": {
@@ -24,6 +24,6 @@
   },
   "homepage": "https://github.com/nanotexnolagiya/zustand-cookie-storage#readme",
   "devDependencies": {
-    "typescript": "^5.4.5"
+    "typescript": "^5.7.3"
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,7 +73,7 @@ export function setCookie(
   value: string,
   options?: CookieAttributes
 ) {
-  let cookieString = `${encodeURIComponent(name)}=${encodeURIComponent(value)}`;
+  let cookieString = `${encodeName(name)}=${encodeValue(value)}`;
 
   if (options) {
     if (options.expires) {
@@ -107,3 +107,13 @@ export function setCookie(
 export function deleteCookie(name: string) {
   document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
 }
+
+const encodeName = (name: string) =>
+  encodeURIComponent(name)
+  .replace(/%(2[346B]|5E|60|7C)/g, decodeURIComponent)
+
+const encodeValue = (value: string) =>
+  encodeURIComponent(value as string).replace(
+    /%(2[346BF]|3[AC-F]|40|5[BDE]|60|7[BCD])/g,
+    decodeURIComponent
+  )


### PR DESCRIPTION
### Issue
After setting any value to any store variable, all the store cookies being reset.

### Possible cause
Looks like wrong cookie name causes removal not only of `key` but of all the cookies

### Fix
Sets correct cookie key. So cookie is not removed on key-value set

**Before:** `my-storage%7Cstate%7Cmy-value`
**After:** `my-storage|state|my-value`

### Note
I think it could be missing after removing js-cookie, I've found this fix here:
https://github.com/carhartl/typescript-cookie/blob/main/src/codec.ts